### PR TITLE
docs: ローカルでの起動方法を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # Gardencity-Bus-Time
+
+## How to develop
+
+repository root で `npx http-server` を実行すると、http://127.0.0.1:8080 で起動します
+
+```
+Need to install the following packages:
+  http-server@14.1.1
+Ok to proceed? (y) y
+Starting up http-server, serving ./
+
+http-server version: 14.1.1
+
+http-server settings:
+CORS: disabled
+Cache: 3600 seconds
+Connection Timeout: 120 seconds
+Directory Listings: visible
+AutoIndex: visible
+Serve GZIP Files: false
+Serve Brotli Files: false
+Default File Extension: none
+
+Available on:
+  http://127.0.0.1:8080
+  http://192.168.0.21:8080
+Hit CTRL-C to stop the server
+```


### PR DESCRIPTION
htmlをブラウザに読ませてもいいですが、確認しやすいので追記しました。